### PR TITLE
Changed example to be consistent with docs

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -62,7 +62,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "examples": [{"title": "some.text.binding", "helpText": "some.other.text.binding" }]
+          "examples": [{"title": "some.text.binding", "help": "some.other.text.binding" }]
         },
         "dataModelBindings": {
           "type": "object",


### PR DESCRIPTION
`helpText` does not actually do anything.