### PR TITLE
Removed tt02 from NKR

### DIFF
--- a/orgs/altinn-orgs.json
+++ b/orgs/altinn-orgs.json
@@ -143,9 +143,7 @@
             "logo": "https://altinncdn.no/orgs/nkr/kulturradet.png",
             "orgnr": "971527412",
             "homepage": "https://www.kulturradet.no",
-            "environments": [
-                "tt02"
-            ]
+            "environments": []
         },
         "nav": {
             "name": {


### PR DESCRIPTION
nkr does not have a tt02 cluster.