### PR TITLE
Add JSON schema pattern for layout.id

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -35,6 +35,7 @@
         "id": {
           "type": "string",
           "title": "id",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_]+[a-zA-Z0-9]$",
           "description": "The component ID. Must be unique within a given layout."
         },
         "type": {


### PR DESCRIPTION
The json schema suggest all strings are valid for the ID field, but `.` is known to fail in the editor (without any explanation).

I'm not sure what the real requirements are but I picked a reasonable conservative option where first and last character is alpha numeric, and the middle characters also can be `-` or `_`.

Explanation from https://regex101.com
![image](https://user-images.githubusercontent.com/131616/135988979-b03109ae-7bb6-47b7-8817-cdc83f683c02.png)
