### PR TITLE
Specify that groupComponents.children, needs to be unique

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -236,7 +236,7 @@
       "properties": {
         "children": {
           "title": "Children",
-          "description": "An array of child components belonging to the group.",
+          "description": "An array of the \"id\" of child components belonging to the group.",
           "type": "array",
           "items": {
             "type": "string"


### PR DESCRIPTION
Altinn studio designer crashes if there are duplicate entries in groupComponents.children. It will be much easier to catch if VSCode complains.

![image](https://user-images.githubusercontent.com/131616/138686672-d5836493-6b77-4093-aade-cecd0abfc533.png)
