### PR TITLE
fix: update documentation to specify correct default value for timestamp

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -197,8 +197,8 @@
         "timeStamp": {
           "type": "boolean",
           "title": "Time stamp",
-          "description": "Boolean value indicating if the date time should be stored as a timeStamp. Defaults to false.",
-          "default": false
+          "description": "Boolean value indicating if the date time should be stored as a timeStamp. Defaults to true.",
+          "default": true
         }
       },
       "required": []


### PR DESCRIPTION

The current implementation actually defaults to 'undefined', and there is a strict check if the timestamp is set to 'false'.
The result of this check (timestamp === false) will only be true if timestamp is 'false'. 'undefined' (default) will not result in this check evaluating to 'true'.