### PR TITLE
Schema support for "saveWhileTyping" property

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -123,6 +123,7 @@
         { "if": {"properties": {"type": { "const": "Group"}}}, "then": { "$ref": "#/definitions/groupComponent"}},
         { "if": {"properties": {"type": { "const": "Image"}}}, "then": { "$ref": "#/definitions/imageComponent"}},
         { "if": {"properties": {"type": { "const": "Input"}}}, "then": { "$ref": "#/definitions/inputComponent"}},
+        { "if": {"properties": {"type": { "const": "TextArea"}}}, "then": { "$ref": "#/definitions/textAreaComponent"}},
         { "if": {"properties": {"type": { "const": "InstantiationButton"}}}, "then": { "$ref": "#/definitions/instantiationButtonComponent"}},
         { "if": {"properties": {"type": { "const": "NavigationButtons"}}}, "then": { "$ref": "#/definitions/navigationButtonsComponent"}},
         { "if": {"properties": {"type": { "const": "RadioButtons"}}}, "then": { "$ref": "#/definitions/radioAndCheckboxComponents"}},
@@ -458,30 +459,30 @@
           "description": "Boolean value indicating if the options should be instance aware. Defaults to false. See more on docs: https://docs.altinn.studio/app/development/data/options/"
         },
         "source": {
-            "type": "object",
-            "title": "Source",
-            "description": "Object to define a data model source to be used as basis for options. Can not be used if options or optionId is set. See more on docs: https://docs.altinn.studio/app/development/data/options/",
-            "properties": {
-                "group": {
-                    "type": "string",
-                    "title": "Group",
-                    "description": "The repeating group to base options on.",
-                    "examples": ["model.some.group"]
-                },
-                "label": {
-                    "type": "string",
-                    "title": "Label",
-                    "description": "Reference to a text resource to be used as the option label.",
-                    "examples": ["some.text.key"]
-                },
-                "value": {
-                    "type": "string",
-                    "title": "Label",
-                    "description": "Field in the group that should be used as value",
-                    "examples": ["model.some.group[{0}].someField"]
-                }
+          "type": "object",
+          "title": "Source",
+          "description": "Object to define a data model source to be used as basis for options. Can not be used if options or optionId is set. See more on docs: https://docs.altinn.studio/app/development/data/options/",
+          "properties": {
+            "group": {
+              "type": "string",
+              "title": "Group",
+              "description": "The repeating group to base options on.",
+              "examples": ["model.some.group"]
             },
-            "required": ["group", "label", "value"]
+            "label": {
+              "type": "string",
+              "title": "Label",
+              "description": "Reference to a text resource to be used as the option label.",
+              "examples": ["some.text.key"]
+            },
+            "value": {
+              "type": "string",
+              "title": "Label",
+              "description": "Field in the group that should be used as value",
+              "examples": ["model.some.group[{0}].someField"]
+            }
+          },
+          "required": ["group", "label", "value"]
         }
       }
     },
@@ -503,6 +504,9 @@
           "title": "Simplified",
           "description": "Boolean value indicating if the address component should be shown in simple mode.",
           "default": false
+        },
+        "saveWhileTyping": {
+          "$ref": "#/definitions/saveWhileTyping"
         }
       }
     },
@@ -580,8 +584,27 @@
           "title": "Input formatting",
           "description": "Set of options for formatting input fields.",
           "$ref": "#/definitions/inputFormatting"
+        },
+        "saveWhileTyping": {
+          "$ref": "#/definitions/saveWhileTyping"
         }
       }
+    },
+    "textAreaComponent": {
+      "properties": {
+        "saveWhileTyping": {
+          "$ref": "#/definitions/saveWhileTyping"
+        }
+      }
+    },
+    "saveWhileTyping": {
+      "title": "Automatic saving while typing",
+      "description": "Boolean or number. True = feature on (default), false = feature off (saves on focus blur), number = timeout in milliseconds (400 by default)",
+      "default": true,
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "number" }
+      ]
     },
     "inputFormatting": {
       "properties": {


### PR DESCRIPTION
## Description
Support for saving while typing (with a 400ms timeout by default) should be possible to configure/disable per component. This adds layout schema support for overriding the timeout (or disabling it) on `Input`, `TextArea` and `AddressComponent`.

## Related Issue(s)
- Altinn/app-frontend-react/pull/305

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- ~~[ ] All tests run green~~

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
