### PR TITLE
Updated schema for openByDefault

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -419,8 +419,14 @@
         },
         "openByDefault": {
           "title": "Open by default",
-          "description": "Boolean value indicating if group should be opened to add a new item by default when no items exist.",
-          "type": "boolean"
+          "description": "Boolean or string indicating if group should be opened by default. If no items exist: 'first', 'last', and true adds a new item. If items are prefilled: 'first' and true opens the first item, and 'last' opens the last item in the group.",
+          "oneOf": [
+            { "type": "boolean" },
+            {
+              "type": "string",
+              "enum": ["first", "last"]
+            }
+          ]
         }
       }
     },

--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -419,7 +419,7 @@
         },
         "openByDefault": {
           "title": "Open by default",
-          "description": "Boolean or string indicating if group should be opened by default. If no items exist: 'first', 'last', and true adds a new item. If items are prefilled: 'first' and true opens the first item, and 'last' opens the last item in the group.",
+          "description": "Boolean or string indicating if group should be opened by default. If no items exist: 'first', 'last', and true adds a new item. If items exist already, true does not open anything, but 'first' opens the first item, and 'last' opens the last item in the group.",
           "oneOf": [
             { "type": "boolean" },
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates schema for openByDefault property for repeating groups to support 'first' and 'last' values in addition to boolean values. See the [app-frontend PR](https://github.com/Altinn/app-frontend-react/pull/519).

## Related Issue(s)
- Altinn/app-frontend-react#396

