### PR TITLE
Added saveAndNextButton to groupEditOptions

### DIFF
--- a/schemas/json/layout/layout.schema.v1.json
+++ b/schemas/json/layout/layout.schema.v1.json
@@ -421,6 +421,11 @@
           "title": "Open by default",
           "description": "Boolean value indicating if group should be opened to add a new item by default when no items exist.",
           "type": "boolean"
+        },
+        "saveAndNextButton": {
+          "title": "Save and open next button",
+          "description": "Boolean value indicating whether save and go to next button should be shown or not in addition to save and close button in edit mode of repeating group item.",
+          "type": "boolean"
         }
       }
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added edit option for save and open next button for repeating groups

## Related Issue(s)
- Altinn/app-frontend-react#395

