### PR TITLE
Adding note about moved JsonSchema files

### DIFF
--- a/schemas/json/README.md
+++ b/schemas/json/README.md
@@ -1,0 +1,7 @@
+## JsonSchemas
+
+Some/most of these files are managed in the `app-frontend-react` repo instead, as changes in them are directly related
+to frontend releases, meaning they should follow the same release schedule. All changes from that repo will
+automatically overwrite the files in this repo.
+
+[Latest versions of these files](https://github.com/Altinn/app-frontend-react/tree/main/schemas/json) 


### PR DESCRIPTION
## Description
The other PRs in this repo for changing JsonSchema files should be closed now, as changes in these files have been taken over by the `app-frontend-react` repo, and changes from there will be pushed here and overwrite these files (just like any other release of `app-frontend-react` does in the `toolkits` folder).

This PR adds a note about that, hopefully to deter others from creating PRs in this repo.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/pull/613