### PR TITLE
Change organization name of DIHE to Digitale Helgeland

### DIFF
--- a/orgs/altinn-orgs.json
+++ b/orgs/altinn-orgs.json
@@ -70,9 +70,9 @@
         },
         "dihe": {
             "name": {
-                "en": "Digital Helgeland c/o Brønnøy municipality",
-                "nb": "Digitale Helgeland v/Brønnøy kommune",
-                "nn": "Digitale Helgeland v/Brønnøy kommune"
+                "en": "Digital Helgeland ",
+                "nb": "Digitale Helgeland",
+                "nn": "Digitale Helgeland"
             },
             "logo": "",
             "orgnr": "964983291",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change organization name of DIHE from Digitale Helgeland v/Brønnøy kommune to Digitale Helgeland.
