### PR TITLE
Remove duplicate font-faces

### DIFF
--- a/fonts/altinn-din/altinn-din.css
+++ b/fonts/altinn-din/altinn-din.css
@@ -1,171 +1,98 @@
 @font-face {
-  font-family: 'Altinn-DIN Condensed';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINCondensed-Bold.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINCondensed-Bold.woff') format('woff');
+  font-family: "Altinn-DIN Condensed";
+  src: url("https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINCondensed-Bold.woff2") format("woff2"),
+    url("https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINCondensed-Bold.woff") format("woff");
   font-weight: bold;
   font-style: normal;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Altinn-DIN';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN-Bold.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN-Bold.woff') format('woff');
+  font-family: "Altinn-DIN";
+  src: url("https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN-Bold.woff2") format("woff2"),
+    url("https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN-Bold.woff") format("woff");
   font-weight: bold;
   font-style: normal;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Altinn-DIN';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN-Bold.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN-Bold.woff') format('woff');
+  font-family: "Altinn-DIN";
+  src: url("https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN-Bold.woff2") format("woff2"),
+    url("https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN-Bold.woff") format("woff");
   font-weight: 500;
   font-style: normal;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Altinn-DIN';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN-Bold.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN-Bold.woff') format('woff');
+  font-family: "Altinn-DIN";
+  src: url("https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN-Bold.woff2") format("woff2"),
+    url("https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN-Bold.woff") format("woff");
   font-weight: 600;
   font-style: normal;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Altinn-DIN';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN-Bold.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN-Bold.woff') format('woff');
+  font-family: "Altinn-DIN";
+  src: url("https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN-Bold.woff2") format("woff2"),
+    url("https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN-Bold.woff") format("woff");
   font-weight: 700;
   font-style: normal;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Altinn-DIN';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN.woff') format('woff');
+  font-family: "Altinn-DIN";
+  src: url("https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN.woff2") format("woff2"),
+    url("https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN.woff") format("woff");
   font-weight: normal;
   font-style: normal;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Altinn-DIN Exp';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINExp-Bold.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINExp-Bold.woff') format('woff');
+  font-family: "Altinn-DIN Exp";
+  src: url("https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINExp-Bold.woff2") format("woff2"),
+    url("https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINExp-Bold.woff") format("woff");
   font-weight: bold;
   font-style: normal;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Altinn-DIN';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN-Italic.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN-Italic.woff') format('woff');
+  font-family: "Altinn-DIN";
+  src: url("https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN-Italic.woff2") format("woff2"),
+    url("https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN-Italic.woff") format("woff");
   font-weight: normal;
   font-style: italic;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Altinn-DIN Exp';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINExp.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINExp.woff') format('woff');
+  font-family: "Altinn-DIN Exp";
+  src: url("https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINExp.woff2") format("woff2"),
+    url("https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINExp.woff") format("woff");
   font-weight: normal;
   font-style: normal;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Altinn-DIN Condensed';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINCondensed.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINCondensed.woff') format('woff');
+  font-family: "Altinn-DIN Condensed";
+  src: url("https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINCondensed.woff2") format("woff2"),
+    url("https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINCondensed.woff") format("woff");
   font-weight: normal;
   font-style: normal;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Altinn-DIN Exp';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINExp-Italic.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINExp-Italic.woff') format('woff');
-  font-weight: normal;
-  font-style: italic;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Altinn-DIN Condensed';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINCondensed.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINCondensed.woff') format('woff');
-  font-weight: normal;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Altinn-DIN';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN.woff') format('woff');
-  font-weight: normal;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Altinn-DIN';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN-Bold.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN-Bold.woff') format('woff');
-  font-weight: bold;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Altinn-DIN';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DIN-Italic.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DIN-Italic.woff') format('woff');
+  font-family: "Altinn-DIN Exp";
+  src: url("https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINExp-Italic.woff2") format("woff2"),
+    url("https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINExp-Italic.woff") format("woff");
   font-weight: normal;
   font-style: italic;
   font-display: swap;
 }
-
-@font-face {
-  font-family: 'Altinn-DIN Exp';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINExp-Italic.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINExp-Italic.woff') format('woff');
-  font-weight: normal;
-  font-style: italic;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Altinn-DIN Condensed';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINCondensed-Bold.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINCondensed-Bold.woff') format('woff');
-  font-weight: bold;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Altinn-DIN Exp';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINExp-Bold.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINExp-Bold.woff') format('woff');
-  font-weight: bold;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Altinn-DIN Exp';
-  src: url('https://altinncdn.no/fonts/altinn-din/woff2/Altinn-DINExp.woff2') format('woff2'),
-      url('https://altinncdn.no/fonts/altinn-din/woff/Altinn-DINExp.woff') format('woff');
-  font-weight: normal;
-  font-style: normal;
-  font-display: swap;
-}
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

After testing the PDF-service directly in AT22 by manually injecting css into the document, I suspect that the duplicated font-faces could have something to do with the weird behavior with fonts on PDF generation. If not, it does not hurt to remove duplicated font-faces anyways.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/917

