### PR TITLE
delay news with one day

### DIFF
--- a/studio/designer/news/news.nb.json
+++ b/studio/designer/news/news.nb.json
@@ -2,7 +2,7 @@
   "$schema": "news.schema.json",
   "news": [
     {
-      "date": "2024-08-06",
+      "date": "2024-08-07",
       "title": "Prosessverktøyet støtter nå betaling.",
       "content": "Du kan nå legge til betalingssteg i prosessen."
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Show payment news tomorrow instead of today, since the deploy of studio is delayed.

## Related Issue(s)
- PR itself

