### PR TITLE
Added query parameters definition to prefill.schema.v1.json

### DIFF
--- a/schemas/json/prefill/prefill.schema.v1.json
+++ b/schemas/json/prefill/prefill.schema.v1.json
@@ -1,5 +1,5 @@
 {
-    "$id":"https://altinncdn.no/schemas/json/prefill/prefill.schema.v1.json",
+    "$id": "https://altinncdn.no/schemas/json/prefill/prefill.schema.v1.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Altinn Prefill",
     "description": "Schema that describes the prefill configuration for Altinn applications.",
@@ -21,6 +21,10 @@
         "DSF": {
             "type": "object",
             "$ref": "#/definitions/DSF"
+        },
+        "QueryParameters": {
+            "type": "object",
+            "$ref": "#/definitions/QueryParameters"
         }
     },
     "definitions": {
@@ -438,6 +442,13 @@
                     "title": "AddressCity",
                     "description": "The persons address city."
                 }
+            }
+        },
+        "QueryParameters": {
+            "type": "object",
+            "description": "Define allowed query parameters (key), and the data model field it should be mapped to (value).",
+            "additionalProperties": {
+                "type": "string"
             }
         }
     }


### PR DESCRIPTION
## Description

Altinn Apps now support prefilling based on URL parameters.
They valid parameters and the field it should map to  must be configured in <datamodel>.prefill.json.
This PR adds this support to prefill.schema.v1.json.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/265

## Related PRs

https://github.com/Altinn/app-frontend-react/pull/2951
https://github.com/Altinn/app-lib-dotnet/pull/1068

## Verification
- [x] **Your** code builds clean without any errors or warnings (in the linked PRs)
- [x] Manual testing done (required) (in the linked PRs)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out) (in the linked PRs)
- [x] All tests run green (in the linked PRs)

## Documentation

Docs will be added later.
