### PR TITLE
testData.json schema - let systems be null/undefined

### DIFF
--- a/schemas/json/test-users/test-users.schema.v1.json
+++ b/schemas/json/test-users/test-users.schema.v1.json
@@ -231,6 +231,6 @@
         }
       }
     },
-    "required": ["persons", "orgs", "systems"],
+    "required": ["persons", "orgs"],
     "additionalProperties": false
 }


### PR DESCRIPTION
## Description
Let the systems array be null/undefined so that users don't get warnings if validating an old version of `testData.json` against the new schema

## Related Issue(s)
- https://github.com/Altinn/altinn-cdn/pull/204

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
