### PR TITLE
Add service owners from Altinn 2 (tt02)

### DIFF
--- a/orgs/altinn-orgs.json
+++ b/orgs/altinn-orgs.json
@@ -138,7 +138,7 @@
         },
         "dihe": {
             "name": {
-                "en": "Digital Helgeland ",
+                "en": "Digital Helgeland",
                 "nb": "Digitale Helgeland",
                 "nn": "Digitale Helgeland"
             },
@@ -241,9 +241,9 @@
         },
         "fk": {
             "name": {
-                "en": "Fellesordn for avtalefestet pensjon",
-                "nb": "Fellesordn for avtalefestet pensjon",
-                "nn": "Fellesordn for avtalefestet pensjon"
+                "en": "Fellesordningen for avtalefestet pensjon",
+                "nb": "Fellesordningen for avtalefestet pensjon",
+                "nn": "Fellesordninga for avtalefesta pensjon"
             },
             "orgnr": "987414502",
             "homepage": "",
@@ -979,7 +979,7 @@
         },
         "tts": {
             "name": {
-                "en": "Test Ministry (OLD)",
+                "en": "Test Ministry (old)",
                 "nb": "Testdepartementet (gammel)",
                 "nn": "Testdepartementet (gammel)"
             },
@@ -1108,7 +1108,7 @@
             "name": {
                 "en": "Norwegian Water Resources and Energy Directorate",
                 "nb": "Norges vassdrags- og energidirektorat",
-                "nn": "Norges vassdrags- og energidirektoratt"
+                "nn": "Norges vassdrags- og energidirektorat"
             },
             "orgnr": "970205039",
             "homepage": "https://www.nve.no/",
@@ -1153,7 +1153,7 @@
                 "nn": "Politiet"
             },
             "orgnr": "982531950",
-            "homepage": "https://www.datatilsynet.no/",
+            "homepage": "",
             "environments": []
         },
         "sht": {


### PR DESCRIPTION
## Description
Adding a few service owners that have appeared in Storage in TT02 as owners of migrated Altinn 2 apps. We need these to ensure that the "Service List" feature in Altinn 2 works as it's including Apps from Storage and mering the service owners from this file.

I didn't bother to translate any names and made sure that organization numbers were reasonable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded the public organization catalog with many new entries (ABC, ACN, ASF, BFT, DRM, EHLS, FK, FK30, KURS, K0220, K0231, KMD, NPT, SI, STFK, TTS), making them discoverable.

- **Chores**
  - Renamed Trondheim listing for consistency (k5501 → k5001).
  - Removed logo from Digital Helgeland entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->