### PR TITLE
Require orgno

### DIFF
--- a/orgs/altinn-orgs.schema.v1.json
+++ b/orgs/altinn-orgs.schema.v1.json
@@ -43,10 +43,7 @@
             },
             "orgnr": {
               "type": "string",
-              "oneOf": [
-                {"const": ""},
-                {"pattern": "^[0-9]{9}$"}
-              ]
+              "pattern": "^[0-9]{9}$"
             },
             "homepage": {
               "type": "string",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Organization number now must be exactly 9 digits; empty values are no longer accepted.
  * Users must enter a valid 9-digit organization number when creating or editing records, improving data quality and preventing invalid submissions.
* Refactor
  * Consolidated organization number validation into a single rule for clearer, more predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->