### PR TITLE
feat: validate all orgs have orgnr set using jq

### DIFF
--- a/.github/workflows/validate-json-syntax.yaml
+++ b/.github/workflows/validate-json-syntax.yaml
@@ -31,6 +31,10 @@ jobs:
         run: |
           echo "Validating orgs/altinn-orgs.json syntax..."
           jq empty orgs/altinn-orgs.json
+      
+      - name: Validate all orgs have orgnr except ttd
+        run: |
+          jq '.orgs | to_entries | map(select(.key != "ttd" and (.value.orgnr | (type == "string" and test("^[0-9]{9}$")) | not)) | "Org '\''\(.key)'\'' has invalid orgnr: '\''\(.value.orgnr)'\''") | if length > 0 then error("Validation failed:\n" + join("\n")) else "All orgs are valid." end' orgs/altinn-orgs.json
 
       - name: Validate orgs/altinn-orgs.json schema
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a CI validation step that checks all organization entries (excluding the “ttd” org) include a 9‑digit organization number. The workflow fails with detailed messages on violations and confirms success when all pass. Introduces an additional gate after JSON syntax checks. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->