### PR TITLE
Add production env for vigo

### DIFF
--- a/orgs/altinn-orgs.json
+++ b/orgs/altinn-orgs.json
@@ -1096,7 +1096,8 @@
             "orgnr": "998283914",
             "homepage": "https://www.novari.no/",
             "environments": [
-                "tt02"
+                "tt02",
+                "production"
             ],
             "contact": {
                 "url": "https://novari.no/kontakt/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Prod env is added https://vigo.apps.altinn.no/kuberneteswrapper/api/v1/deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Vigo organization is now available in the Production environment in addition to TT02. Users affiliated with Vigo can access and use Vigo services in live production.
  - No other organizations are affected by this update.
- Chores
  - Updated organization environment configuration to reflect Production availability for Vigo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->