### PR TITLE
Add BFT, ACN

### DIFF
--- a/orgs/altinn-orgs.json
+++ b/orgs/altinn-orgs.json
@@ -1,5 +1,14 @@
 {
     "orgs": {
+         "acn": {
+            "name": {
+                "en": "ACN Test org",
+                "nb": "ACN Test org",
+                "nn": "ACN Test org"
+            },
+            "orgnr": "999999990",
+            "environments": []
+        },
         "afs": {
             "name": {
                 "en": "Avfall Sør AS",
@@ -9,6 +18,15 @@
             "logo": "https://altinncdn.no/orgs/afs/afs.svg",
             "orgnr": "995646137",
             "homepage": "https://avfallsor.no/",
+            "environments": []
+        },
+        "bft": {
+            "name": {
+                "en": "BFT Test org",
+                "nb": "BFT Test org",
+                "nn": "BFT Test org"
+            },
+            "orgnr": "999999991",
             "environments": []
         },
         "brg": {


### PR DESCRIPTION
This adds BFT and ACN as orgs to ensure RR entries for migrated test-apps are represented correctly in RR. Using invalid organization numbers to avoid relations with actual entities, as this is used for authorization purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added two new organizations with multilingual naming support to the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->