### PR TITLE
Update altinn-orgs.json

### DIFF
--- a/orgs/altinn-orgs.json
+++ b/orgs/altinn-orgs.json
@@ -35,11 +35,10 @@
                 "nb": "BITS AS",
                 "nn": "BITS AS"
             },
-            "logo": null,
+            "logo": "https://altinncdn.no/orgs/bits/bits.png",
             "orgnr": "916960190",
             "homepage": "https://bits.no/",
-            "environments": [
-            ]
+            "environments": []
         },
         "brg": {
             "name": {


### PR DESCRIPTION
Lagt til BITS AS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BITS AS as a recognized organization in the system (org. number 916960190).
  * Organization includes multilingual display names, a public homepage link, and a branded logo for user-facing listings.
  * BITS AS is available for selection in organization pickers and will appear in relevant directory and affiliation views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->